### PR TITLE
fix(bash-loader-imports): Fix importing .bash_loader

### DIFF
--- a/dot_bash_loader/main.tmpl
+++ b/dot_bash_loader/main.tmpl
@@ -26,12 +26,12 @@ do
 done
 
 ## Source bash_loader aliases
-if [[ -f "$HOME/.bash_loader/.bash_aliases" ]]; then
+if [[ -f "$HOME/.bash_loader/bash_aliases" ]]; then
   . "$HOME/.bash_loader/aliases"
 fi
 
 ## Source bash_loader env
-if [[ -f "$HOME/.bash_loader/.env" ]]; then
+if [[ -f "$HOME/.bash_loader/env" ]]; then
   . "$HOME/.bash_loader/env"
 fi
 

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -102,12 +102,12 @@ alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo
 
 ## Source .bash_aliases if it exists
 if [ -f ~/.bash_aliases ]; then
-    . ~/.bash_aliases > /dev/null
+    . ~/.bash_aliases
 fi
 
 ## Source .bash_loader if it exists
 if [ -f ~/.bash_loader/main ]; then
-  . ~/.bash_loader/main > /dev/null
+  . ~/.bash_loader/main
 fi
 
 ## Enable programmable completion features (you don't need to enable


### PR DESCRIPTION
Edit typos in .bash_loader/main.

Remove > /dev/null from imports in .bashrc