### PR TITLE
atuin: Switch to emacs mode

### DIFF
--- a/home/dot_config/atuin/config.toml.tmpl
+++ b/home/dot_config/atuin/config.toml.tmpl
@@ -72,7 +72,7 @@ command_chaining = true
 enter_accept = true
 
 # Keymap mode for interactive search. Options: emacs (default), vim-normal, vim-insert, auto
-keymap_mode = "vim-normal"
+keymap_mode = "emacs"
 
 # Dict mapping defining cursors for each mode. Cursor styles are "blink-block" and "steady-block"
 keymap_cursor = { emacs = "blink-block", vim_insert = "steady-block", vim_normal = "steady-block" }


### PR DESCRIPTION
Fixes the right arrow key, which now inserts the highlighted history item