### PR TITLE
zsh: Fix insecure compinit dir

### DIFF
--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -70,6 +70,19 @@ setopt NO_CASE_GLOB
 ## Set shell to emacs mode
 bindkey -e
 
+## Fix insecure directories before compinit
+() {
+  local dirs=(
+    "{{ .chezmoi.homeDir }}/.local/share/zsh"
+    "{{ .chezmoi.homeDir }}/.local/share/zsh/site-functions"
+  )
+  for dir in "${dirs[@]}"; do
+    mkdir -p "$dir"
+    chmod 755 "$dir"
+    chown jack:jack "$dir" 2>/dev/null || true
+  done
+}
+
 ## Allow editing a command with CTRL+X + e
 autoload -Uz edit-command-line
 zle -N edit-command-line


### PR DESCRIPTION
Each time the shell loads, ensure ~/.local/share/zsh and ~/.local/share/zsh/site-functions have chmod 755