### PR TITLE
fix(pager): Add empty GIT_PAGER env var to zshrc

### DIFF
--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -269,6 +269,7 @@ done
 
 export PAGER=less
 export LESS=-R
+export GIT_PAGER=
 
 ## Locale
 export LANG="en_US.UTF-8"


### PR DESCRIPTION
This prevents the 'less'-like output of `git branch`