### PR TITLE
fix(yazi): Fix yazi open action

### DIFF
--- a/home/dot_config/yazi/keymap.toml
+++ b/home/dot_config/yazi/keymap.toml
@@ -578,3 +578,4 @@ desc = "Chmod on selected files"
 on = "<C-d>"
 run = "plugin diff"
 desc = "Diff the selected with the hovered file"
+

--- a/home/dot_config/yazi/yazi.toml
+++ b/home/dot_config/yazi/yazi.toml
@@ -28,8 +28,9 @@ ueberzug_offset = [0, 0, 0, 0]
 
 [opener]
 edit = [
-    { run = '${EDITOR:-vi} "$@"', desc = "$EDITOR", block = true, for = "unix" },
-    { run = 'nvim "$@"', block = true, desc = "nvim", for = "unix" },
+    # { run = '${EDITOR:-vi} "$@"', desc = "$EDITOR", block = true, for = "unix" },
+    { run = '$EDITOR "$@"', desc = "editor", block = true, for = "unix"},
+    # { run = 'nvim "$@"', block = true, desc = "nvim", for = "unix" },
     { run = 'code %*', orphan = true, desc = "code", for = "windows" },
     { run = 'code -w %*', block = true, desc = "code (block)", for = "windows" },
 ]
@@ -270,7 +271,8 @@ sort_translit = false
 
 ## mime-ext https://github.com/yazi-rs/plugins/tree/main/mime-ext.yazi
 [[plugin.prepend_fetchers]]
-id = "mime"
+id = "mime-ext"
 url = "*"
 run = "mime-ext.local"
-prio = "high"
+prio = "normal"
+


### PR DESCRIPTION
Create fetcher for yazi, stop overriding default mime fetcher. This fixes the `o` bind not working