### PR TITLE
fix(tmux): Fix tmux crash on neovim open

### DIFF
--- a/home/dot_bashrc.tmpl
+++ b/home/dot_bashrc.tmpl
@@ -121,7 +121,13 @@ fi
 ## Opening neovim in tmux when connected via SSH crashes the tmux server,
 #  unless the TMUX env var is set to something (anything).
 #  https://github.com/tmux/tmux/issues/3983#issuecomment-2224545592
-export TMUX=1
+# if [[ -n "$SSH_CONNECTION" ]] && [[ -z "$TMUX" ]]; then
+#   export TMUX=1
+# fi
+
+if [ -n "$SSH_CONNECTION" ] && [ -z "$TMUX" ] && [[ $TERM == *sixel* || $TERM == termix* ]]; then
+  export TMUX=1
+fi
 
 ## Source ~/.local/bin/env if it exists
 [ ! -f "{{ .chezmoi.homeDir }}/.local/bin/env" ] || . "{{ .chezmoi.homeDir }}/.local/bin/env"

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -283,7 +283,13 @@ fi
 ## Opening neovim in tmux when connected via SSH crashes the tmux server,
 #  unless the TMUX env var is set to something (anything).
 #  https://github.com/tmux/tmux/issues/3983#issuecomment-2224545592
-export TMUX=1
+# if [[ -n "$SSH_CONNECTION" ]] && [[ -z "$TMUX" ]]; then
+#   export TMUX=1
+# fi
+
+if [ -n "$SSH_CONNECTION" ] && [ -z "$TMUX" ] && [[ $TERM == *sixel* || $TERM == termix* ]]; then
+  export TMUX=1
+fi
 
 ##################
 # Prompt Options #


### PR DESCRIPTION
Settings TMUX=1 did not resolve the problem. Instead, the fix now detects a SIXEL terminal and temporarily sets the TMUX value, allowing tmux to override it once it's open.

Settings TMUX=1 breaks the smart-splits plugin, but this fix addresses both issues.